### PR TITLE
Fix order of require/log

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -7,8 +7,8 @@ let to5;
 try {
   to5 = require(resolve.sync('6to5', { basedir: process.cwd() }));
 } catch(_) {
-  console.warn('Coverage using inner 6to5. version : ' + to5.version);
   to5 = require('6to5');
+  console.warn('Coverage using inner 6to5. version : ' + to5.version);
 }
 
 import esprima from 'esprima';
@@ -103,4 +103,3 @@ export class Instrumenter extends istanbul.Instrumenter {
     return lastLine;
   }
 }
-


### PR DESCRIPTION
Can't log `to5.version` if it hasn't been required.