### PR TITLE
Change 6to5 dependency to 6to5-core

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -10,9 +10,11 @@ var _get = function get(object, property, receiver) { var desc = Object.getOwnPr
 
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
 
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
 var istanbul = _interopRequire(require("istanbul"));
 
-var to5 = _interopRequire(require("6to5"));
+var to5 = _interopRequire(require("6to5-core"));
 
 var esprima = _interopRequire(require("esprima"));
 
@@ -25,6 +27,8 @@ var SourceMapGenerator = _sourceMap.SourceMapGenerator;
 var Instrumenter = exports.Instrumenter = (function (_istanbul$Instrumenter) {
   function Instrumenter() {
     var options = arguments[0] === undefined ? {} : arguments[0];
+    _classCallCheck(this, Instrumenter);
+
     this.to5Options = _extends({
       sourceMap: true }, options && options.to5 || {});
 
@@ -86,7 +90,7 @@ var Instrumenter = exports.Instrumenter = (function (_istanbul$Instrumenter) {
           br.line = brLine;
         });
 
-        return _get(Object.getPrototypeOf(Instrumenter.prototype), "getPreamble", this).call(this, sourceCode, emitUseStrict);
+        return _get(_istanbul$Instrumenter.prototype, "getPreamble", this).call(this, sourceCode, emitUseStrict);
       },
       writable: true,
       configurable: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "license": "WTFPL",
   "dependencies": {
-    "6to5": "^3.2.1",
+    "6to5-core": "^3.2.1",
     "escodegen": "^1.4.0",
     "esprima": "^1.2.2",
     "istanbul": "^0.3.2",
@@ -42,6 +42,7 @@
     "which": "^1.0.5"
   },
   "devDependencies": {
+    "6to5": "^3.2.1",
     "chai": "^1.10.0",
     "mocha": "^2.0.1"
   },

--- a/register.js
+++ b/register.js
@@ -1,1 +1,1 @@
-require("6to5/register")(require('./.6to5rc'));
+require("6to5-core/register")(require('./.6to5rc'));

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -1,6 +1,6 @@
 
 import istanbul from 'istanbul';
-import to5 from '6to5';
+import to5 from '6to5-core';
 
 import esprima from 'esprima';
 import escodegen from 'escodegen';


### PR DESCRIPTION
Tools such as '6to5ify' or 'gulp-6to5' use '6to5-core', not '6to5'. This PR moves '6to5' to devDependencies and adds '6to5-core' as a lib dependency.