### PR TITLE
add a test to make sure it exports all the public istanbul symbols

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,12 @@
+
+import {expect} from 'chai';
+
+// using require here instead of import to avoid babel messing with it
+const istanbul = require('istanbul');
+const isparta = require('../');
+
+describe('API', function () {
+  it('should include all the public istanbul symbols', function () {
+    expect(isparta).to.contain.all.keys(istanbul);
+  });
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -39,7 +39,7 @@ const MAP_TYPES = [
 let instumenterSuite = describe("Isparta instrumenter", function () {
   before(generateSourceMapTest);
 
-  it('soulhd generate the tests', function () {
+  it('should generate the tests', function () {
     expect(instumenterSuite.suites.length).to.be.above(0);
   });
 


### PR DESCRIPTION
The currently compiled version on npm does not export the correct symbols, instead it exports them behind a "default" key. That’s a problem from babels code generation.
Compiling it locally with the latest babel version fixes that problem, so I can use isparta as a drop-in replacement for istanbul.

All you really need to do is recompile with the latest babel. But that in turn breaks half the tests, since you make some assumptions on the generated code as far as I can see.