### PR TITLE
Stop hard coding nomnom location

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "istanbul": "^0.3.13",
     "lodash.partial": "^3.1.0",
     "mkdirp": "^0.5.0",
-    "nomnom": "douglasduteil/nomnom#next",
+    "nomnom": "^1.8.1",
     "source-map": "^0.4.2",
     "which": "^1.0.9"
   },


### PR DESCRIPTION
nomnom install failing from the hard-coded dependency.

Installing the latest version cures this and `npm test` output is unchanged