### PR TITLE
Add support for istanbul option 'include-all-sources'

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -51,6 +51,10 @@ nomnom.command('cover')
     abbr: 'v',
     help: 'verbose mode'
   })
+  .option('include-all-sources', {
+    flag: true,
+    help: 'include-all-sources'
+  })
 
   .callback(opts => {
 


### PR DESCRIPTION
To also include the coverage for files without tests i think it would be good to support theIstanbul command line option 'include-all-sources'.