### PR TITLE
Issue #45: Fixed mixed ES6 and CommonJS exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "license": "WTFPL",
   "dependencies": {
-    "babel-core": "^5.0.4",
+    "babel-core": "~5.0.4",
     "escodegen": "^1.6.1",
     "esprima": "^2.1.0",
     "istanbul": "^0.3.13",
@@ -44,7 +44,7 @@
     "which": "^1.0.9"
   },
   "devDependencies": {
-    "babel": "^5.0.4",
+    "babel": "~5.0.4",
     "chai": "^2.2.0",
     "hide-stack-frames-from": "^1.0.0",
     "mocha": "^2.2.1",

--- a/src/isparta.js
+++ b/src/isparta.js
@@ -1,4 +1,6 @@
 import * as istanbul from 'istanbul';
+import { Instrumenter } from './instrumenter';
+import { version } from '../package.json';
 
 for (var key in istanbul) {
 	if (istanbul.hasOwnProperty(key)) {
@@ -6,5 +8,5 @@ for (var key in istanbul) {
 	}
 }
 
-export {Instrumenter} from './instrumenter';
-export {version} from '../package.json';
+exports.Instrumenter = Instrumenter;
+exports.version = version;


### PR DESCRIPTION
Hi, this is a fix for issue #45.

The problem is that the isparta.js source file was exporting its properties in both CommonJS and ES6 modules. This does not cause any problems when executed from a "normal" ES5 application, but when run in a babel-transpiled application and imported as an ES6 module (like in the mentioned issue with gulp babel), those exports are treated differently, and the actual object that gets imported only contains the properties of the original Istanbul module - including the instrumenter.

The solution for this is to be consistent in the exports, by either choosing the ES6 style or the CommonJS. In this case the only option is to use the CommonJS approach, because ES6 does not allow exporting dynamic properties - see [this SO question](http://stackoverflow.com/questions/29844074/es6-export-all-values-from-object).

With this fix, it is possible to use the instrumenter as per the documentation (require/import 'isparta', then use `isparta.Instrumenter`).

Note that it was always possible to import the instrumenter directly as an ES6 module:

```
import { Instrumenter } from 'isparta';
```

The above solution works even without the fix in this PR, but it's not documented anywhere. This PR is to make sure that the instrumenter can be used as documented when using an ES6 module.

Note: I also had to restrict the range for the babel dependency in package.json, otherwise the tests would fail - this is because the expected values in the fixtures contain hard-coded line numbers, which are not guaranteed to be the same across versions of the babel transpiler.