### PR TITLE
Fix for issue #55 and #56

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -43,6 +43,7 @@ nomnom.command('cover')
   .option('include', {
     default: ['**/*.js'],
     metavar: '<include-pattern>',
+    list: true,
     abbr: 'i',
     help: 'one or more fileset patterns e.g. \'**/*.js\''
   })
@@ -64,7 +65,6 @@ nomnom.command('cover')
         if (file) files = files.concat(file);
     });
 
-    opts.include = [opts.include];
     opts.include = opts.include.concat(files);
 
     coverCmd(opts);
@@ -183,7 +183,7 @@ function coverCmd(opts) {
     let instrumenter = new Instrumenter({ coverageVariable : coverageVar });
     let transformer = instrumenter.instrumentSync.bind(instrumenter);
 
-    hook.hookRequire(matchFn, transformer, { verbose : opts.verbose });
+    hook.hookRequire(matchFn, transformer, Object.assign({ verbose : opts.verbose }, config.instrumentation.config));
 
     global[coverageVar] = {};
 


### PR DESCRIPTION
Hi @douglasduteil, I think isparta is a great work for es6 code coverage. :+1: 
I found some issues when I used it in my es6 code.

1. Option 'include' must be a list. So there will no need to transform to an Array.

2. Istanbul configuration doesn't really pass in function.

And consider this commit 5d72ef1c70c22bf0ebf616a53dd6eced29c9a3ed for the failed test issue
