### PR TITLE
Moves babel-core to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Isparta can be installed using
 $ npm install --save-dev isparta
 ```
 
+Isparta relies on babel for ES6 transpilation. Install it using
+
+```sh
+$ npm install --save-dev babel-core
+```
+
 ## Usage
 
 **Not all the istanbul command/options are available with isparta**  

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "url": "git://github.com/douglasduteil/isparta.git"
   },
   "license": "WTFPL",
+  "peerDependencies": {
+    "babel-core": "*"
+  },
   "dependencies": {
-    "babel-core": "^5.8.23",
     "escodegen": "^1.6.1",
     "esprima": "^2.1.0",
     "istanbul": "^0.3.13",
@@ -46,6 +48,7 @@
   },
   "devDependencies": {
     "babel": "^5.8.23",
+    "babel-core": "^5.8.23",
     "chai": "^3.2.0",
     "hide-stack-frames-from": "^1.0.0",
     "mocha": "^2.2.1",


### PR DESCRIPTION
I see that you are [requiring babel-core as a dependency](https://github.com/douglasduteil/isparta/blob/b86e8212df39bcf34cc2c9752940a58d71baa952/package.json#L36). This theoretically can get you into trouble if your tests are using a different version of babel than your regular webpack loader or whatever.

Usually packages like this that rely on a version of babel [specify it as a peer dependency](https://github.com/babel/babel-loader/blob/f299837e39f53e45b66722de6e39b9b42eb3ff69/package.json#L11-L14).

https://docs.npmjs.com/files/package.json#peerdependencies