### PR TITLE
Add basic support for istanbul ignore

### DIFF
--- a/test/fixtures/es6-classes/expectedCover.js
+++ b/test/fixtures/es6-classes/expectedCover.js
@@ -19,7 +19,7 @@ function generateNSkipedStatement(n){
 function generateNSkipedFunction(...lostFnData){
   return lostFnData.map(fnData => {
     return {
-      ...fnData, loc: {...lostStatment}, skip: true
+      ...fnData, loc: {...skippedStatment}, skip: true
     };
   });
 }

--- a/test/fixtures/virgin/actual.js
+++ b/test/fixtures/virgin/actual.js
@@ -3,3 +3,8 @@
 ONE.foo = function (bar) {
   return baz(bar ? 0 : 1);
 };
+
+/* istanbul ignore next */
+if (true) {
+  var a = 5;
+}

--- a/test/fixtures/virgin/expectedCover.js
+++ b/test/fixtures/virgin/expectedCover.js
@@ -1,31 +1,50 @@
 // Compiled to
 
-// 1. "use strict";
-// 2.
-// 3. ONE.foo = function (bar) {
-// 4.   return baz(bar ? 0 : 1);
-// 5. };
+//  1. "use strict";
+//  2.
+//  3. ONE.foo = function (bar) {
+//  4.   return baz(bar ? 0 : 1);
+//  5. };
+//  6.
+//  7. /* istanbul ignore next */
+//  8. if (true) {
+//  9.   var a = 5;
+// 10. }
 
 
 module.exports = {
   statementMap: [
     {
-      // 3. ONE.foo = function (bar) {
-      // 4.   return baz(bar ? 0 : 1);
-      // 5. };
+      //  3. ONE.foo = function (bar) {
+      //  4.   return baz(bar ? 0 : 1);
+      //  5. };
       start: {line: 3, column: 0},
       end: {line: 5, column: 2}
     },
     {
-      // 4.   return baz(bar ? 0 : 1);
+      //  4.   return baz(bar ? 0 : 1);
       start: {line: 4, column: 2},
       end: {line: 4, column: 26}
+    },
+    {
+      //  8. if (true) {
+      //  9.   var a = 5;
+      // 10. }
+      start: {line: 8, column: 0},
+      end: {line: 10, column: 1},
+      skip: true
+    },
+    {
+      //  9.   var a = 5;
+      start: {line: 9, column: 2},
+      end: {line: 9, column: 12},
+      skip: true
     }
   ],
 
   fnMap: [
     {
-      // 3. ONE.foo = function (bar) {
+      //  3. ONE.foo = function (bar) {
       name: '(anonymous_1)', line: 3,
       loc: {
         start: {line: 3, column: 10},
@@ -36,7 +55,7 @@ module.exports = {
 
   branchMap: [
     {
-      // 4.   return baz(bar ? 0 : 1);
+      //  4.   return baz(bar ? 0 : 1);
       line: 4, type: 'cond-expr',
       locations: [
         {
@@ -46,6 +65,22 @@ module.exports = {
         {
           start: {line: 4, column: 23},
           end: {line: 4, column: 24}
+        }
+      ]
+    },
+    {
+      //  8. if (true) {
+      line: 8, type: 'if',
+      locations: [
+        {
+          start: {line: 8, column: 0},
+          end: {line: 8, column: 0},
+          skip: true
+        },
+        {
+          start: {line: 8, column: 0},
+          end: {line: 8, column: 0},
+          skip: true
         }
       ]
     }


### PR DESCRIPTION
Fixes #24 

I kept the behavior from `_fnMapTransformer` of completely skipping the `skip` key.