### PR TITLE
chore(dependencies): Update istanbul to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-core": "^5.8.23",
     "escodegen": "^1.6.1",
     "esprima": "^2.1.0",
-    "istanbul": "^0.3.13",
+    "istanbul": "^0.4.0",
     "lodash.partial": "^3.1.0",
     "mkdirp": "^0.5.0",
     "nomnomnomnom": "^2.0.0",


### PR DESCRIPTION
As istanbul isn't 1.0.0, `^0.3.13` will only match `0.3.x`, meaning isparta uses `0.3.22`. Karma coverage however has been updated to use istanbul `0.4.0` with the new html design. This means the new stylesheets are used by karma coverage but the old html handlebar templates are used by isparta. As the html and the stylesheets don't match up it gives broken looking html reports like this where the progress bars are set to 100px instead of 100%:

<img width="1155" alt="screen shot 2015-10-26 at 14 13 06" src="https://cloud.githubusercontent.com/assets/6425649/10731131/c7f50a6c-7beb-11e5-9443-06af590310a3.png">

Another possible fix could be just to set istanbul as a peer dependency to this module and leave it up to the user which version to install.