### PR TITLE
fix(cli): typo trailing "s"

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -186,7 +186,7 @@ function coverCmd(opts) {
 
     matcherFor({
       root: config.instrumentation.root() || process.cwd(),
-      includes: opts.includes || config.instrumentation.extensions()
+      includes: opts.include || config.instrumentation.extensions()
         .map((ext) => '**/*' + ext),
       excludes: excludes
     }, (err, matchFn) => {


### PR DESCRIPTION
Fixes #82