### PR TITLE
Reverting config parsing changes to preserve .istanbul.yml functionality

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -32,7 +32,6 @@ nomnom.command('cover')
     help: 'the configuration file to use, defaults to .istanbul.yml'
   })
   .option('default-excludes', {
-    default: true,
     flag: true,
     help: 'apply default excludes [ **/node_modules/**, **/test/**, **/tests/** ]'
   })
@@ -50,7 +49,6 @@ nomnom.command('cover')
     help: 'report format'
   })
   .option('root', {
-    default: '.',
     metavar: '<path>',
     help: 'the root path to look for files to instrument'
   })
@@ -67,7 +65,6 @@ nomnom.command('cover')
     help: 'verbose mode'
   })
   .option('include-all-sources', {
-    default: false,
     flag: true,
     help: 'instrument all unused sources after running tests'
   })


### PR DESCRIPTION
Commit fb4dea9502e9784303fe48a4f4add3bde28a90ba introduced a backwards-incompatible change, breaking the expectations that values set in the .istanbul.yml config file would be used if the corresponding parameter wasn't set to override it.  For instance, running with isparta@3.1.0 with this `.istanbul.yml` (notice the non-default values):

```yaml
verbose: true
instrumentation:
    root: ./app
    default-excludes: false
    include-all-sources: true
```

and the following command (executed via npm):

```bash
babel-node $(npm bin)/isparta cover $(npm bin)/_mocha --compilers js:babel/register -- --recursive
```

Would result with the following output during coverage:

```yaml
verbose: true
instrumentation:
    root: ./app
    default-excludes: false
    include-all-sources: true
    ...
```

However, each version since the aforementioned change disregards certain values in the `.istanbul.yaml`, specifically `root`, `include-all-sources`, and `default-excludes`, resulting in the following:

```yaml
verbose: true
instrumentation:
    root: .
    default-excludes: true
    include-all-sources: false
    ...
```

Turns out it has to do with how the arguments are being passed to Istanbul's configuration functions.  For instance, [`mergeObjects`](https://github.com/gotwarlost/istanbul/blob/master/lib/config.js#L83
) overwrites template values with whatever is being passed in as the override.  You'll notice this works for some of the other default parameter values set up here because they're empty arrays (which `mergeObjects` discards in favor of what has been loaded from the config file).

It's probably worth revisiting how to make this configuration more robust, but I wanted to offer a quick solution to reestablish this functionality quickly, as I (and perhaps others) are going to have to stay pinned to `3.1.0` for the time being.