### PR TITLE
Manually export istanbul modules

### DIFF
--- a/src/isparta.js
+++ b/src/isparta.js
@@ -1,3 +1,3 @@
-export * from 'istanbul';
+export {Store, Collector, hook, Report, config, Reporter, utils, matcherFor, Writer, ContentWriter, FileWriter, _yuiLoadHook, TreeSummarizer, assetsDir} from 'istanbul';
 export {Instrumenter} from './instrumenter';
 export {VERSION} from '../package.json';


### PR DESCRIPTION
until babel transpiling is fixed: https://github.com/babel/babel/issues/2763

This will introduce technical debt until the issue is fixed, but it does gets isparta compiling.