### PR TITLE
Remove process.exit(0) from processEnding to fix false positives on CI server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 lib/
+npm-debug.log

--- a/src/cli/commands/cover.js
+++ b/src/cli/commands/cover.js
@@ -181,5 +181,4 @@ function processEnding (err) {
     console.error(err);
     process.exit(1);
   }
-  process.exit(0);
 }


### PR DESCRIPTION
Using `[substack/tape](https://github.com/substack/tape)` as an example, the test harness listens for `process.exit` before printing results, and conditionally calling `process.exit()` with a non zero exit code.

I noticed that with a failing tests, `tape` does not even print the results because the exit routine is hijacked:

![image](https://cloud.githubusercontent.com/assets/4420103/13730126/3bcc7076-e91d-11e5-8f42-605171890132.png)

At the moment, the `processEnding` function in `cover.js` causes the process to exit with an exit code of `0` (as long as istanbul has no errors with coverage). As a consequence, the tests are assumed to have finished without error. This means that generating coverage on travis (or any other CI server) requires running the test suite twice unless you want to get false positives. 

FYI, there were already 4 failing tests -- this patch didn't cause those.

Correct me if I'm wrong -- but removing this `process.exit()` call shouldn't affect any users unless their test suite hangs by itself.
