### PR TITLE
Update to latest esprima for enabling instrumentation of async/await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,3 @@ sudo: false
 language: node_js
 node_js:
 - 'stable'
-- '5'
-- '4'
-- 'io.js'
-- '0.12'
-- '0.10'

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "babel-core": "^6.1.4",
     "escodegen": "^1.6.1",
-    "esprima": "^2.1.0",
+    "esprima": "^4.0.0",
     "istanbul": "^0.4.0",
     "mkdirp": "^0.5.0",
     "nomnomnomnom": "^2.0.0",

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -3,7 +3,7 @@
 import istanbul from 'istanbul';
 import {transform as babelTransform} from 'babel-core';
 
-import esprima from 'esprima';
+import { parse } from 'esprima';
 import escodegen from 'escodegen';
 
 import {SourceMapConsumer} from 'source-map';
@@ -30,7 +30,7 @@ export class Instrumenter extends istanbul.Instrumenter {
     this._babelMap = new SourceMapConsumer(result.map);
 
     // PARSE
-    let program = esprima.parse(result.code, {
+    let program = parse(result.code, {
       loc: true,
       range: true,
       tokens: this.opts.preserveComments,


### PR DESCRIPTION
This update allows isparta to instrument async/await functions without babel