### PR TITLE
support javascript w/ bash shebang (#!)

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -30,6 +30,7 @@ export class Instrumenter extends istanbul.Instrumenter {
     this._babelMap = new SourceMapConsumer(result.map);
 
     // PARSE
+    result.code = result.code.replace(/^#!.+[\r\n]/, '\n');
     let program = parse(result.code, {
       loc: true,
       range: true,


### PR DESCRIPTION
for example, the `_mocha` binary.

resolves the following error:
```
Transformation error; return original code                                                                                                                                                                           
{ Error: Line 1: Unexpected token ILLEGAL                                                                                                                                                                            
    at ErrorHandler.constructError (node_modules/isparta/node_modules/esprima/dist/esprima.js:5012:22)                                                                                            
    at ErrorHandler.createError (node_modules/isparta/node_modules/esprima/dist/esprima.js:5028:27)                                                                                               
    at ErrorHandler.throwError (node_modules/isparta/node_modules/esprima/dist/esprima.js:5035:21)                                                                                                
    at Scanner.throwUnexpectedToken (node_modules/isparta/node_modules/esprima/dist/esprima.js:5164:35)                                                                                           
    at Scanner.scanPunctuator (node_modules/isparta/node_modules/esprima/dist/esprima.js:5667:19)                                                                                                 
    at Scanner.lex (node_modules/isparta/node_modules/esprima/dist/esprima.js:6264:22)
    at Parser.nextToken (node_modules/isparta/node_modules/esprima/dist/esprima.js:2079:34)
    at new Parser (node_modules/isparta/node_modules/esprima/dist/esprima.js:1916:15)
    at parse (node_modules/isparta/node_modules/esprima/dist/esprima.js:120:19)
    at Instrumenter.instrumentSync (node_modules/isparta/lib/instrumenter.js:66:40)
  index: 0,
  lineNumber: 1,
  description: 'Unexpected token ILLEGAL' }
```